### PR TITLE
DAQprocess refinement with future

### DIFF
--- a/include/app-framework/DAQProcess.hh
+++ b/include/app-framework/DAQProcess.hh
@@ -54,7 +54,7 @@ class DAQProcess {
      * if so, first send the command to the UserModules in that list in the order specified. Then, any
      * remaining UserModules will receive the command in an unspecified order.
      */
-    void execute_command(std::string cmd);
+    void execute_command( const std::string & cmd );
     /**
      * @brief Start the CommandFacility listener
      * @return Return code from listener

--- a/src/DAQProcess.cc
+++ b/src/DAQProcess.cc
@@ -40,8 +40,9 @@ void DAQProcess::execute_command(std::string cmd) {
     if (commandOrderMap_.count(cmd)) {
         for (auto& moduleName : commandOrderMap_[cmd]) {
             if (userModuleMap_.count(moduleName)) {
-                userModuleMap_[moduleName]->execute_command(cmd);
-                user_module_list.erase(moduleName);
+	        auto cmd_result = userModuleMap_[moduleName]->execute_command(cmd);
+		TLOG(TLVL_DEBUG) << moduleName << " processed \"" << cmd << "\" with result: " << cmd_result.get() ;
+	        user_module_list.erase(moduleName);
             }
         }
     } else {
@@ -51,7 +52,9 @@ void DAQProcess::execute_command(std::string cmd) {
 
     TLOG(TLVL_DEBUG) << "Executing Command " << cmd << " for all remaining UserModules";
     for (auto const& moduleName : user_module_list) {
-        userModuleMap_[moduleName]->execute_command(cmd);
+        auto cmd_result = userModuleMap_[moduleName]->execute_command(cmd);
+	TLOG(TLVL_DEBUG) << moduleName << " processed \"" << cmd << "\" with result: " << cmd_result.get() ;
+	user_module_list.erase(moduleName);
     }
 }
 


### PR DESCRIPTION
This pull requests implement the simplest pattern that uses the future returned from a UserModule during a transition. So far this was unused. Once configuration will be more elaborate these patterns can be complicated depending on configuration or requirements from the UserModule implementations. 