### PR TITLE
QueueRegistry fix: missing return

### DIFF
--- a/include/app-framework/QueueRegistry.icc
+++ b/include/app-framework/QueueRegistry.icc
@@ -21,6 +21,8 @@ QueueRegistry::get_queue(std::string name) {
 
         throw QueueTypeMismatch(ERS_HERE, name, realname_source, realname_target);
       }
+
+      return queuePtr;
   } 
 
   auto itP = this->queue_configmap_.find(name);


### PR DESCRIPTION
Thanks to @philiprodrigues for spotting a silly mistake in `QueueRegistry::get_queue`.
When requesting the an existing queue, the lack of a return statement resulted in the queue to be re-created. Fixed.